### PR TITLE
Prefix-less command Fix. 

### DIFF
--- a/NamazuKingdom/Modules/CommandProxyModule.cs
+++ b/NamazuKingdom/Modules/CommandProxyModule.cs
@@ -1,0 +1,66 @@
+﻿using Discord;
+using Discord.Commands;
+using NamazuKingdom.Helpers;
+using NamazuKingdom.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NamazuKingdom.Modules
+{
+    // Class to execute TTS as a command still. 
+    public class CommandProxyModule : ModuleBase<SocketCommandContext>
+    {
+
+        private readonly AudioService _audioService;
+        private readonly DatabaseServices _databaseServices;
+        public CommandProxyModule(AudioService audioService, DatabaseServices dbServices)
+        {
+            _audioService = audioService;
+            _databaseServices = dbServices;
+        }
+
+        [Command("tts")]
+        public async Task TTSAsync([Remainder] string sound)
+        {
+            Console.WriteLine("TTS Started:");
+            Console.WriteLine(sound);
+            //todo null handle
+            if (Context.User == null) return;
+
+            var botVoice = await _databaseServices.UserTTSVoice(Context.User.Id);
+
+            if (string.IsNullOrWhiteSpace(sound))
+            {
+                await ReplyAsync("Please provide search terms.");
+                return;
+            }
+            Console.WriteLine("Pass null or white space test. ");
+            Console.WriteLine("Guild ID:");
+            Console.WriteLine(Context.Guild.Id);
+            if (_audioService.IsConnected(Context.Guild.Id) == false)
+            {
+                await ReplyAsync("Audio client is null, am I connected to a voice channel?");
+                return;
+            }
+            Console.WriteLine("Pass Guild Connection test. ");
+            if (string.IsNullOrWhiteSpace(sound))
+                return;
+            if (sound.Contains("https://") || sound.Contains("http://"))
+                return;
+            Console.WriteLine("Pass URL. ");
+            if ((Context.User as IGuildUser)?.VoiceChannel == null ||
+                (Context.User as IGuildUser)?.VoiceChannel != _audioService.GetCurrentVoiceChannel(Context.Guild.Id))
+            {
+                await ReplyAsync("You are not connected to the same voice channel as the bot.");
+                return;
+            }
+            Console.WriteLine("Test this");
+            var url = $"https://api.streamelements.com/kappa/v2/speech?voice={botVoice}&text={StringHelpers.CleanTTSString(sound)}";//+StringHelpers.CleanTTSString(sound);
+            Console.WriteLine(url);
+            await _audioService.SendAsync(url, Context.Guild.Id);
+        }
+    }
+}

--- a/NamazuKingdom/Modules/CommandProxyModule.cs
+++ b/NamazuKingdom/Modules/CommandProxyModule.cs
@@ -22,11 +22,10 @@ namespace NamazuKingdom.Modules
             _databaseServices = dbServices;
         }
 
+        // TEMPORARY: Need to come up with a static model so we don't have two versions of the same functionality floating about.
         [Command("tts")]
         public async Task TTSAsync([Remainder] string sound)
         {
-            Console.WriteLine("TTS Started:");
-            Console.WriteLine(sound);
             //todo null handle
             if (Context.User == null) return;
 
@@ -37,29 +36,22 @@ namespace NamazuKingdom.Modules
                 await ReplyAsync("Please provide search terms.");
                 return;
             }
-            Console.WriteLine("Pass null or white space test. ");
-            Console.WriteLine("Guild ID:");
-            Console.WriteLine(Context.Guild.Id);
             if (_audioService.IsConnected(Context.Guild.Id) == false)
             {
                 await ReplyAsync("Audio client is null, am I connected to a voice channel?");
                 return;
             }
-            Console.WriteLine("Pass Guild Connection test. ");
             if (string.IsNullOrWhiteSpace(sound))
                 return;
             if (sound.Contains("https://") || sound.Contains("http://"))
                 return;
-            Console.WriteLine("Pass URL. ");
             if ((Context.User as IGuildUser)?.VoiceChannel == null ||
                 (Context.User as IGuildUser)?.VoiceChannel != _audioService.GetCurrentVoiceChannel(Context.Guild.Id))
             {
                 await ReplyAsync("You are not connected to the same voice channel as the bot.");
                 return;
             }
-            Console.WriteLine("Test this");
             var url = $"https://api.streamelements.com/kappa/v2/speech?voice={botVoice}&text={StringHelpers.CleanTTSString(sound)}";//+StringHelpers.CleanTTSString(sound);
-            Console.WriteLine(url);
             await _audioService.SendAsync(url, Context.Guild.Id);
         }
     }

--- a/NamazuKingdom/Services/CommandHandler.cs
+++ b/NamazuKingdom/Services/CommandHandler.cs
@@ -47,6 +47,10 @@ namespace NamazuKingdom.Services
         private async Task HandleCommandAsync(SocketMessage messageParam)
         {
             // Don't process the command if it was a system message
+            var checkFlag = 0; 
+            Console.WriteLine("Handle COmmand Async being activated.");
+            Console.WriteLine($"{checkFlag}");
+            checkFlag++; 
             var message = messageParam as SocketUserMessage;
             if (message == null) return;
 
@@ -54,6 +58,8 @@ namespace NamazuKingdom.Services
             int argPos = 0;
 
             // Check to see if the user wants to use TTS without prefix
+            Console.WriteLine(message.Author); 
+            Console.WriteLine(message.Content); 
             bool shouldTTS = false;
             var userWantsTTS = await _databaseServices.UserWantsTTS(message.Author.Id);
             if (!message.HasCharPrefix('-', ref argPos) && userWantsTTS)
@@ -65,7 +71,9 @@ namespace NamazuKingdom.Services
                 message.HasMentionPrefix(_client.CurrentUser, ref argPos)) ||
                 message.Author.IsBot)
                 return;
-
+            Console.WriteLine(shouldTTS); 
+            Console.WriteLine($"{checkFlag}");
+            checkFlag++;
             // Create a WebSocket-based command context based on the message
             var context = new SocketCommandContext(_client, message);
 
@@ -83,6 +91,9 @@ namespace NamazuKingdom.Services
                 try
                 {
                     //_commands.CommandExecuted += OnCommandExecutedAsync;
+                    Console.WriteLine("Execute Command.");
+                    Console.WriteLine(context.Message.Content);
+                    Console.WriteLine(message); 
                     await _commands.ExecuteAsync(
                         context: context,
                         input: "tts " + context.Message.Content,

--- a/NamazuKingdom/Services/CommandHandler.cs
+++ b/NamazuKingdom/Services/CommandHandler.cs
@@ -47,10 +47,6 @@ namespace NamazuKingdom.Services
         private async Task HandleCommandAsync(SocketMessage messageParam)
         {
             // Don't process the command if it was a system message
-            var checkFlag = 0; 
-            Console.WriteLine("Handle COmmand Async being activated.");
-            Console.WriteLine($"{checkFlag}");
-            checkFlag++; 
             var message = messageParam as SocketUserMessage;
             if (message == null) return;
 
@@ -58,8 +54,6 @@ namespace NamazuKingdom.Services
             int argPos = 0;
 
             // Check to see if the user wants to use TTS without prefix
-            Console.WriteLine(message.Author); 
-            Console.WriteLine(message.Content); 
             bool shouldTTS = false;
             var userWantsTTS = await _databaseServices.UserWantsTTS(message.Author.Id);
             if (!message.HasCharPrefix('-', ref argPos) && userWantsTTS)
@@ -71,9 +65,6 @@ namespace NamazuKingdom.Services
                 message.HasMentionPrefix(_client.CurrentUser, ref argPos)) ||
                 message.Author.IsBot)
                 return;
-            Console.WriteLine(shouldTTS); 
-            Console.WriteLine($"{checkFlag}");
-            checkFlag++;
             // Create a WebSocket-based command context based on the message
             var context = new SocketCommandContext(_client, message);
 
@@ -91,9 +82,6 @@ namespace NamazuKingdom.Services
                 try
                 {
                     //_commands.CommandExecuted += OnCommandExecutedAsync;
-                    Console.WriteLine("Execute Command.");
-                    Console.WriteLine(context.Message.Content);
-                    Console.WriteLine(message); 
                     await _commands.ExecuteAsync(
                         context: context,
                         input: "tts " + context.Message.Content,


### PR DESCRIPTION
With introduction of slash commands, using the TTS without a prefix broke. 
This fixes it. 
However, will need to introduce static class that allows for both the slash command implemention and prefix command implementation to call the same function, rather than have copy pasta'd versions of the same point. 